### PR TITLE
Fixes key and string tables ordering + changes some helper functions

### DIFF
--- a/BYAMLSharp/BYAML.cs
+++ b/BYAMLSharp/BYAML.cs
@@ -29,7 +29,14 @@ public struct BYAML
 
     public ushort Version { get; set; } = 1;
 
+    /// <summary>
+    /// DictionaryKeyTable is a StringTable node that includes all the property names in the yaml, keys of the dictionaries
+    /// </summary>
     public BYAMLNode DictionaryKeyTable { get; internal set; } = new(BYAMLNodeType.Null);
+    
+    /// <summary>
+    /// StringTable is a StringTable node that includes all the string values in the yaml, values of the dictionaries that use string 
+    /// </summary>
     public BYAMLNode StringTable { get; internal set; } = new(BYAMLNodeType.Null);
     public BYAMLNode PathTable { get; internal set; } = new(BYAMLNodeType.Null);
     public BYAMLNode RootNode { get; set; }

--- a/BYAMLSharp/BYAMLBuilder.cs
+++ b/BYAMLSharp/BYAMLBuilder.cs
@@ -163,7 +163,7 @@ public class BYAMLBuilder
     /// </summary>
     public BYAML ToBYAML() => new(_rootNode, isMKBYAML: _isMK);
 
-    private void AddNode(BYAMLNode node, string? key)
+    public void AddNode(BYAMLNode node, string? key)
     {
         switch (_currentNode.NodeType)
         {

--- a/BYAMLSharp/BYAMLNode.cs
+++ b/BYAMLSharp/BYAMLNode.cs
@@ -31,6 +31,17 @@ public class BYAMLNode
         };
     }
 
+    public BYAMLNode(BYAMLNodeType type, object? val, bool isMKBYAML = false)
+    {
+        NodeType = type;
+        _value = val;
+    }
+    public BYAMLNode(BYAMLNodeType type, Dictionary<string, BYAMLNode> val)
+    {
+        NodeType = type;
+        _value = val.OrderBy(x => x.Key, StringComparer.Ordinal).ToDictionary();
+    }
+
     public BYAMLNodeType NodeType { get; }
 
     public object? Value

--- a/BYAMLSharp/BYAMLNode.cs
+++ b/BYAMLSharp/BYAMLNode.cs
@@ -35,13 +35,39 @@ public class BYAMLNode
     {
         NodeType = type;
         _value = val;
+        if (GetType(val) != NodeType) throw new("BYAMLNodeType was incorrectly assigned!");
     }
-    public BYAMLNode(BYAMLNodeType type, Dictionary<string, BYAMLNode> val)
+    public BYAMLNode(object? val)
     {
-        NodeType = type;
+        NodeType = GetType(val);
+        _value = val;
+    }
+    public BYAMLNode(Dictionary<string, BYAMLNode> val)
+    {
+        NodeType = BYAMLNodeType.Dictionary;
         _value = val.OrderBy(x => x.Key, StringComparer.Ordinal).ToDictionary();
     }
-
+    private BYAMLNodeType GetType(object? val)
+    {
+        return val switch
+        {
+            string => BYAMLNodeType.String,
+            BYAMLMKPathPoint[] => BYAMLNodeType.BinaryOrPath,
+            byte[] => BYAMLNodeType.BinaryOrPath,
+            BYAMLNode[] => BYAMLNodeType.Array,
+            Dictionary<string, BYAMLNode> => BYAMLNodeType.Dictionary,
+            string[] => BYAMLNodeType.StringTable,
+            BYAMLMKPathPoint[][] => BYAMLNodeType.PathTable,
+            bool => BYAMLNodeType.Bool,
+            int => BYAMLNodeType.Int,
+            float => BYAMLNodeType.Float,
+            uint => BYAMLNodeType.UInt,
+            long => BYAMLNodeType.Int64,
+            ulong => BYAMLNodeType.UInt64,
+            double => BYAMLNodeType.Double,
+            _ => BYAMLNodeType.Null
+        };
+    }
     public BYAMLNodeType NodeType { get; }
 
     public object? Value

--- a/BYAMLSharp/BYAMLParser.cs
+++ b/BYAMLSharp/BYAMLParser.cs
@@ -480,12 +480,12 @@ public static class BYAMLParser
 
         if (keys.Count > 0)
         {
-            keyTable = new(BYAMLNodeType.StringTable) { Value = keys.OrderBy(x => x, StringComparer.Ordinal).ToList().ToArray() };
+            keyTable = new(BYAMLNodeType.StringTable, keys.OrderBy(x => x, StringComparer.Ordinal).ToList().ToArray());
             }
 
         if (strings.Count > 0)
         {
-            strTable = new(BYAMLNodeType.StringTable) { Value = strings.OrderBy(x => x, StringComparer.Ordinal).ToList().ToArray() };
+            strTable = new(BYAMLNodeType.StringTable, strings.OrderBy(x => x, StringComparer.Ordinal).ToList().ToArray());
         }
 
         if (paths.Count > 0)

--- a/BYAMLSharp/BYAMLParser.cs
+++ b/BYAMLSharp/BYAMLParser.cs
@@ -479,10 +479,14 @@ public static class BYAMLParser
             }
 
         if (keys.Count > 0)
-            keyTable = new(BYAMLNodeType.StringTable) { Value = keys.ToArray() };
+        {
+            keyTable = new(BYAMLNodeType.StringTable) { Value = keys.OrderBy(x => x, StringComparer.Ordinal).ToList().ToArray() };
+            }
 
         if (strings.Count > 0)
-            strTable = new(BYAMLNodeType.StringTable) { Value = strings.ToArray() };
+        {
+            strTable = new(BYAMLNodeType.StringTable) { Value = strings.OrderBy(x => x, StringComparer.Ordinal).ToList().ToArray() };
+        }
 
         if (paths.Count > 0)
             pathTable = new(BYAMLNodeType.PathTable) { Value = paths.ToArray() };


### PR DESCRIPTION
- Added description to DictionaryKeyTable and StringTable
- Made AddNode public so it may be used to make nodes
- Added new constructors to BYAMLNode so they may be created with any given value+type instead of having to modify them after the fact, which makes node dictionaries easier to work with (since they order keys on creation)