### PR TITLE
Fix StringTables sorting

### DIFF
--- a/BYAMLSharp/BYAMLParser.cs
+++ b/BYAMLSharp/BYAMLParser.cs
@@ -483,18 +483,21 @@ public static class BYAMLParser
         Dictionary<string, string> tmpstr = new(); // first string is to be sorted, second is old
         if (keys.Count > 0)
         {
-            foreach (string s in keys)
+            if (encoding.CodePage != Encoding.UTF8.CodePage) // skip if the strings are already UTF8
             {
-                tmpstr.Add(Encoding.UTF8.GetString(encoding.GetBytes(s)), s);
-            }
-            var ls = tmpstr.Keys.ToList();
-            ls.Sort(StringComparer.Ordinal);
+                foreach (string s in keys)
+                {
+                    tmpstr.Add(Encoding.UTF8.GetString(encoding.GetBytes(s)), s);
+                }
+                var ls = tmpstr.Keys.ToList();
+                ls.Sort(StringComparer.Ordinal);
 
-            for (int s = 0; s < ls.Count; s++)
-            {
-                keys[s] = tmpstr[ls[s]];
+                for (int s = 0; s < ls.Count; s++)
+                {
+                    keys[s] = tmpstr[ls[s]];
+                }
             }
-
+            else keys.Sort(StringComparer.Ordinal);
             keyTable = new(
                 BYAMLNodeType.StringTable,
                 keys.ToArray()
@@ -503,18 +506,22 @@ public static class BYAMLParser
 
         if (strings.Count > 0)
         {
-            tmpstr.Clear(); // first string is edited, to be sorted, second is old
-            foreach (string s in strings)
+            if (encoding.CodePage != Encoding.UTF8.CodePage)
             {
-                tmpstr.Add(Encoding.UTF8.GetString(encoding.GetBytes(s)), s);
-            }
-            var ls = tmpstr.Keys.ToList();
-            ls.Sort(StringComparer.Ordinal);
+                tmpstr.Clear();
+                foreach (string s in strings)
+                {
+                    tmpstr.Add(Encoding.UTF8.GetString(encoding.GetBytes(s)), s);
+                }
+                var ls = tmpstr.Keys.ToList();
+                ls.Sort(StringComparer.Ordinal);
 
-            for (int s = 0; s < ls.Count; s++)
-            {
-                strings[s] = tmpstr[ls[s]];
+                for (int s = 0; s < ls.Count; s++)
+                {
+                    strings[s] = tmpstr[ls[s]];
+                }
             }
+            else strings.Sort(StringComparer.Ordinal);
             strTable = new(
                 BYAMLNodeType.StringTable,
                 strings.ToArray()

--- a/BYAMLSharp/BYAMLParser.cs
+++ b/BYAMLSharp/BYAMLParser.cs
@@ -478,19 +478,46 @@ public static class BYAMLParser
                     break;
             }
 
+        Encoding SHIFTJIS = Encoding.GetEncoding(932);
+        Encoding DefEnc = Encoding.Default;
+        Dictionary<string, string> tmpstr = new(); // first string is to be sorted, second is old
         if (keys.Count > 0)
         {
+            foreach (string s in keys)
+            {
+                tmpstr.Add(DefEnc.GetString(SHIFTJIS.GetBytes(s)), s);
+            }
+            var ls = tmpstr.Keys.ToList();
+            ls.Sort(StringComparer.Ordinal);
+
+            for (int s = 0; s < ls.Count; s++)
+            {
+                keys[s] = tmpstr[ls[s]];
+            }
+
             keyTable = new(
                 BYAMLNodeType.StringTable,
-                keys.OrderBy(x => x, StringComparer.Ordinal).ToList().ToArray()
+                keys.ToArray()
             );
         }
 
         if (strings.Count > 0)
         {
+            tmpstr.Clear(); // first string is edited, to be sorted, second is old
+            foreach (string s in strings)
+            {
+                tmpstr.Add(DefEnc.GetString(SHIFTJIS.GetBytes(s)), s);
+            }
+            var ls = tmpstr.Keys.ToList();
+            ls.Sort(StringComparer.Ordinal);
+
+            for (int s = 0; s < ls.Count; s++)
+            {
+                strings[s] = tmpstr[ls[s]];
+            }
             strTable = new(
                 BYAMLNodeType.StringTable,
-                strings.OrderBy(x => x, StringComparer.Ordinal).ToList().ToArray()
+                strings.ToArray()
             );
         }
 

--- a/BYAMLSharp/BYAMLParser.cs
+++ b/BYAMLSharp/BYAMLParser.cs
@@ -25,6 +25,7 @@ public static class BYAMLParser
     {
         GenerateTables(
             byaml.RootNode,
+            byaml.Encoding,
             byaml.IsMKBYAML,
             out BYAMLNode keyTableNode,
             out BYAMLNode strTableNode,
@@ -421,6 +422,7 @@ public static class BYAMLParser
 
     private static void GenerateTables(
         BYAMLNode root,
+        Encoding encoding,
         bool isMKBYAML,
         out BYAMLNode keyTable,
         out BYAMLNode strTable,
@@ -478,14 +480,12 @@ public static class BYAMLParser
                     break;
             }
 
-        Encoding SHIFTJIS = Encoding.GetEncoding(932);
-        Encoding DefEnc = Encoding.Default;
         Dictionary<string, string> tmpstr = new(); // first string is to be sorted, second is old
         if (keys.Count > 0)
         {
             foreach (string s in keys)
             {
-                tmpstr.Add(DefEnc.GetString(SHIFTJIS.GetBytes(s)), s);
+                tmpstr.Add(Encoding.UTF8.GetString(encoding.GetBytes(s)), s);
             }
             var ls = tmpstr.Keys.ToList();
             ls.Sort(StringComparer.Ordinal);
@@ -506,7 +506,7 @@ public static class BYAMLParser
             tmpstr.Clear(); // first string is edited, to be sorted, second is old
             foreach (string s in strings)
             {
-                tmpstr.Add(DefEnc.GetString(SHIFTJIS.GetBytes(s)), s);
+                tmpstr.Add(Encoding.UTF8.GetString(encoding.GetBytes(s)), s);
             }
             var ls = tmpstr.Keys.ToList();
             ls.Sort(StringComparer.Ordinal);


### PR DESCRIPTION
Old version didn't sort some strings from KoopaFirstStage properly, so CameraParam.byml would end up not working after saving

(If we can find some cleaner way to do this I'd be happy to go with it)